### PR TITLE
:recycle: refactor(bash-aliases): clean up code and remove unnecessar…

### DIFF
--- a/src/bash-aliases/devcontainer-feature.json
+++ b/src/bash-aliases/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "bash-aliases",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "Bash Aliases",
     "description": "Loads custom bash aliases from your project's `.devcontainer/etc/bash-aliases` directory.",
     "dependsOn": {

--- a/src/bash-aliases/install.sh
+++ b/src/bash-aliases/install.sh
@@ -5,6 +5,8 @@ UPDATE_RC="${UPDATE_RC:-"true"}"
 set -eux
 export DEBIAN_FRONTEND=noninteractive
 
+FEATURE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
@@ -22,26 +24,8 @@ updaterc() {
     fi
 }
 
-# Bash-aliases loader
-SNIPPET_CONTENT=$(cat <<'EOF'
-# Only runs on terminal from inside vscode editor, or in CI
-if [[ ( -t 1 && "${TERM_PROGRAM}" = "vscode" ) || "${CI}" = "true" ]]; then
-    ALIASES_FOLDER="$PWD/.devcontainer/etc/bash-aliases"
-
-    # Dynamically load all *.sh files from ALIASES_FOLDER
-    if [ -d "$ALIASES_FOLDER" ]; then
-        for file in "$ALIASES_FOLDER/"*.sh; do
-            if [ -e "$file" ] && [ -r "$file" ]; then
-                source "$file"
-            fi
-        done
-    fi
-fi
-EOF
-)
-
-# Install loader
 echo "Installing Loader..."
-updaterc "${SNIPPET_CONTENT}"
+rc_content="$(cat "${FEATURE_DIR}/scripts/rc_snippet.sh")"
+updaterc "${rc_content}"
 
 echo "Done!"

--- a/src/bash-aliases/scripts/rc_snippet.sh
+++ b/src/bash-aliases/scripts/rc_snippet.sh
@@ -1,0 +1,13 @@
+# Only runs on terminal from inside vscode editor
+if [ -t 1 ] && [ "${TERM_PROGRAM}" = "vscode" ]; then
+    ALIASES_FOLDER="$PWD/.devcontainer/etc/bash-aliases"
+
+    # Dynamically load all *.sh files from ALIASES_FOLDER
+    if [ -d "$ALIASES_FOLDER" ]; then
+        for file in "$ALIASES_FOLDER/"*.sh; do
+            if [ -e "$file" ] && [ -r "$file" ]; then
+                source "$file"
+            fi
+        done
+    fi
+fi

--- a/src/bash-aliases/scripts/rc_snippet.sh
+++ b/src/bash-aliases/scripts/rc_snippet.sh
@@ -1,5 +1,5 @@
-# Only runs on terminal from inside vscode editor
-if [ -t 1 ] && [ "${TERM_PROGRAM}" = "vscode" ]; then
+# Only runs on terminal from inside vscode editor, or in CI
+if [[ ( -t 1 && "${TERM_PROGRAM}" = "vscode" ) || "${CI}" = "true" ]]; then
     ALIASES_FOLDER="$PWD/.devcontainer/etc/bash-aliases"
 
     # Dynamically load all *.sh files from ALIASES_FOLDER

--- a/src/uv/devcontainer-feature.json
+++ b/src/uv/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "uv",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "name": "UV",
     "description": "A fast Python package manager written in Rust. Replaces pip, poetry, virtualenv, and more.",
     "options": {

--- a/src/uv/install.sh
+++ b/src/uv/install.sh
@@ -5,6 +5,8 @@ USERNAME="${USERNAME:-"${_REMOTE_USER:-"automatic"}"}"
 UPDATE_RC="${UPDATE_RC:-"true"}"
 UV_INSTALL_DIR="${UV_INSTALL_DIR:-"~/.local/bin"}"
 
+FEATURE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 set -eux
 export DEBIAN_FRONTEND=noninteractive
 
@@ -66,20 +68,14 @@ if ! uv --version &> /dev/null ; then
     # Install dependencies
     check_packages curl unzip tar ca-certificates
 
-    UV_CACHE_SCRIPT="$(cat << 'EOF'
-if [[ ( -t 1 && "${TERM_PROGRAM}" = "vscode" ) || "${CI}" = "true" ]]; then
-    export UV_CACHE_DIR="$PWD/.uv_cache"
-    mkdir -p "$UV_CACHE_DIR"
-fi
-EOF
-)"
-    updaterc "${UV_CACHE_SCRIPT}"
+    rc_content="$(cat "${FEATURE_DIR}/scripts/rc_snippet.sh")"
+    updaterc "${rc_content}"
 
     mkdir -p $UV_INSTALL_DIR
     chown -R "${USERNAME}:${USERNAME}" "${UV_INSTALL_DIR}"
     chmod -R g+r+w "${UV_INSTALL_DIR}"
-
     find "${UV_INSTALL_DIR}" -type d -print0 | xargs -n 1 -0 chmod g+s
+
     echo "Installing UV..."
 
     UV_VERSION=$VERSION

--- a/src/uv/scripts/rc_snippet.sh
+++ b/src/uv/scripts/rc_snippet.sh
@@ -1,0 +1,5 @@
+# Only runs on terminal from inside vscode editor
+if [ -t 1 ] && [ "${TERM_PROGRAM}" = "vscode" ]; then
+    export UV_CACHE_DIR="$PWD/.uv_cache"
+    mkdir -p "$UV_CACHE_DIR"
+fi

--- a/test/bash-aliases/cases/00-test-setup.sh
+++ b/test/bash-aliases/cases/00-test-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/test/bash-aliases/cases/00-test-setup.sh
+++ b/test/bash-aliases/cases/00-test-setup.sh
@@ -11,12 +11,10 @@ check "Environment Info" echo "\
     USER: $USER\n\
     HOME: $HOME\n\
     TERM_PROGRAM: $TERM_PROGRAM\n\
-    CI: $CI\n\
     ALIASES_DIR: $ALIASES_DIR\n"
 
 # Environment Vars
 check "TERM_PROGRAM is vscode" test "$TERM_PROGRAM" = "vscode"
-check "CI is true" test "$CI" = "true"
 check "ALIASES_DIR is set" test -n "$ALIASES_DIR"
 
 # Aliases directory

--- a/test/bash-aliases/cases/00-test-setup.sh
+++ b/test/bash-aliases/cases/00-test-setup.sh
@@ -11,10 +11,12 @@ check "Environment Info" echo "\
     USER: $USER\n\
     HOME: $HOME\n\
     TERM_PROGRAM: $TERM_PROGRAM\n\
+    CI: $CI\n\
     ALIASES_DIR: $ALIASES_DIR\n"
 
 # Environment Vars
 check "TERM_PROGRAM is vscode" test "$TERM_PROGRAM" = "vscode"
+check "CI is true" test "$CI" = "true"
 check "ALIASES_DIR is set" test -n "$ALIASES_DIR"
 
 # Aliases directory

--- a/test/bash-aliases/cases/10-test-alias.sh
+++ b/test/bash-aliases/cases/10-test-alias.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/test/bash-aliases/cases/20-test-no-aliases-folder.sh
+++ b/test/bash-aliases/cases/20-test-no-aliases-folder.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -euo pipefail
 
@@ -6,14 +6,14 @@ set -euo pipefail
 source dev-container-features-test-lib
 
 # Tests before removing aliases directory
-check "directory exists" ls -lha "$ALIASES_DIR"
-check "testalias exists" zsh -ic "command -v testalias"
-check "testalias works" zsh -ic "testalias"
-check "testalias result" zsh -ic "test \"\$(testalias)\" = 'Hello, World!'"
+check "directory exists" bash -ic "test -d '$ALIASES_DIR'"
+check "testalias exists" bash -ic 'command -v testalias'
+check "testalias works" bash -ic 'testalias'
+check "testalias result" bash -ic 'test "$(testalias)" = "Hello, World!"'
 
 # Remove aliases directory
 rm -rf "$ALIASES_DIR"
 
 # Tests after removing aliases directory
-check "directory should NOT exist" test ! -d "$ALIASES_DIR"
-check "testalias should NOT exist" test ! -n "$(zsh -ic 'command -v testalias')"
+check "directory should NOT exist" bash -ic "test ! -f '$ALIASES_DIR'"
+check "testalias should NOT exist" bash -ic 'test ! "$(command -v testalias)"'

--- a/test/bash-aliases/cases/__before.sh
+++ b/test/bash-aliases/cases/__before.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 ##
 # This file runs before each test case.

--- a/test/bash-aliases/setup.sh
+++ b/test/bash-aliases/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -euo pipefail
 

--- a/test/bash-aliases/setup.sh
+++ b/test/bash-aliases/setup.sh
@@ -2,5 +2,6 @@
 
 set -euo pipefail
 
-# Simulate VS Code terminal
+# Simulate VS Code terminal and CI environment
 export TERM_PROGRAM="vscode"
+export CI="true"

--- a/test/bash-aliases/setup.sh
+++ b/test/bash-aliases/setup.sh
@@ -2,6 +2,5 @@
 
 set -euo pipefail
 
-# Simulate VS Code terminal and CI environment
+# Simulate VS Code terminal
 export TERM_PROGRAM="vscode"
-export CI="true"

--- a/test/bash-aliases/test.sh
+++ b/test/bash-aliases/test.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -euo pipefail
 
@@ -33,7 +33,7 @@ for file in ./cases/*.sh; do
     source ./cases/__before.sh
 
     title="$(get_title "$file")"
-    check "[$title]" zsh -i "$file"
+    check "[$title]" bash -i "$file"
 done
 
 # Report result

--- a/test/bash-aliases/test.sh
+++ b/test/bash-aliases/test.sh
@@ -30,10 +30,9 @@ for file in ./cases/*.sh; do
         continue
     fi
 
-    title="$(get_title "$file")"
-
     source ./cases/__before.sh
 
+    title="$(get_title "$file")"
     check "[$title]" zsh -i "$file"
 done
 


### PR DESCRIPTION
…y 'CI' env var

- Removed the 'CI' environment variable from the bash-aliases feature as it was unnecessary.
- Moved the RC snippet to 'scripts/rc_snippet.sh' for better organization.
- Bumped the feature version in 'devcontainer-feature.json' to accommodate these changes.