### PR TITLE
♻️ revert(bash-aliases): switch test suite back to zsh

### DIFF
--- a/src/bash-aliases/devcontainer-feature.json
+++ b/src/bash-aliases/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "bash-aliases",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Bash Aliases",
     "description": "Loads custom bash aliases from your project's `.devcontainer/etc/bash-aliases` directory.",
     "dependsOn": {

--- a/test/bash-aliases/cases/00-test-setup.sh
+++ b/test/bash-aliases/cases/00-test-setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 set -euo pipefail
 

--- a/test/bash-aliases/cases/10-test-alias.sh
+++ b/test/bash-aliases/cases/10-test-alias.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 set -euo pipefail
 

--- a/test/bash-aliases/cases/20-test-no-aliases-folder.sh
+++ b/test/bash-aliases/cases/20-test-no-aliases-folder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 set -euo pipefail
 
@@ -6,14 +6,14 @@ set -euo pipefail
 source dev-container-features-test-lib
 
 # Tests before removing aliases directory
-check "directory exists" bash -ic "test -d '$ALIASES_DIR'"
-check "testalias exists" bash -ic 'command -v testalias'
-check "testalias works" bash -ic 'testalias'
-check "testalias result" bash -ic 'test "$(testalias)" = "Hello, World!"'
+check "directory exists" zsh -ic "test -d '$ALIASES_DIR'"
+check "testalias exists" zsh -ic 'command -v testalias'
+check "testalias works" zsh -ic 'testalias'
+check "testalias result" zsh -ic 'test "$(testalias)" = "Hello, World!"'
 
 # Remove aliases directory
 rm -rf "$ALIASES_DIR"
 
 # Tests after removing aliases directory
-check "directory should NOT exist" bash -ic "test ! -f '$ALIASES_DIR'"
-check "testalias should NOT exist" bash -ic 'test ! "$(command -v testalias)"'
+check "directory should NOT exist" zsh -ic "test ! -f '$ALIASES_DIR'"
+check "testalias should NOT exist" zsh -ic 'test ! "$(command -v testalias)"'

--- a/test/bash-aliases/cases/__before.sh
+++ b/test/bash-aliases/cases/__before.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 ##
 # This file runs before each test case.

--- a/test/bash-aliases/setup.sh
+++ b/test/bash-aliases/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 set -euo pipefail
 

--- a/test/bash-aliases/test.sh
+++ b/test/bash-aliases/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/zsh
 
 set -euo pipefail
 
@@ -33,7 +33,7 @@ for file in ./cases/*.sh; do
     source ./cases/__before.sh
 
     title="$(get_title "$file")"
-    check "[$title]" bash -i "$file"
+    check "[$title]" zsh -i "$file"
 done
 
 # Report result


### PR DESCRIPTION
Fix CI warning messages caused by bash's job control in interactive mode. Since the feature depends on common-utils which provides zsh, there's no compatibility concern in using zsh for testing.

Changes:
- Switch test script interpreter back to #!/bin/zsh
- Change test commands from bash -ic to zsh -ic
- Fix CI errors: "cannot set terminal process group"